### PR TITLE
/users/credits: ibutton should still return uid

### DIFF
--- a/src/routes/compat/users.rs
+++ b/src/routes/compat/users.rs
@@ -102,7 +102,7 @@ pub async fn get_credits(
             Json(json!({
                 "message": format!("Retrieved user with iButton {}", ibutton),
                 "user": {
-                    "uid": uid,
+                    "uid": user.uid,
                     "cn": user.cn,
                     "drinkBalance": format!("{}", user.drinkBalance.unwrap_or(0))
                 }


### PR DESCRIPTION
ADA was broken because `uid` was `None`...